### PR TITLE
Integrate Gutenberg Mobile 1.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-eebc5d8e91a1d90190919f900f924b39c861a528'
     ext.wordPressLoginVersion = '0.0.8'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.64.1'
+    ext.gutenbergMobileVersion = '19-ae654e488b036fe65889acbe36a8fe02bb55c6bd'
     ext.storiesVersion = '1.1.0'
 
     repositories {


### PR DESCRIPTION
## Description
This PR incorporates the 1.0.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/jhnstn/gutenberg-mobile/pull/19

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.