### PR TITLE
Integrate gutenberg-mobile release v2.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.wordPressUtilsVersion = 'develop-eebc5d8e91a1d90190919f900f924b39c861a528'
     ext.wordPressLoginVersion = '0.0.8'
     ext.detektVersion = '1.15.0'
-    ext.gutenbergMobileVersion = 'v1.64.1'
+    ext.gutenbergMobileVersion = '20-d61728b0efd6ef46c58c4f7e8e6ab0160c5af891'
     ext.storiesVersion = '1.1.0'
 
     repositories {


### PR DESCRIPTION
## Description
This PR incorporates the 2.2.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/jhnstn/gutenberg-mobile/pull/20

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.