### PR TITLE
Integrate gutenberg-mobile release v2.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.4.0'
     automatticTracksVersion = '3.3.0'
-    gutenbergMobileVersion = 'v1.110.0-alpha2'
+    gutenbergMobileVersion = '31-9e94b1dc0a74f34f4945995494df1612bd7837ee'
     wordPressAztecVersion = 'v1.9.0'
     wordPressFluxCVersion = 'trunk-a7668041a4e3e135b19dc3c52a90bd0c7259f133'
     wordPressLoginVersion = '1.10.0'


### PR DESCRIPTION
## Description
This PR incorporates the 2.0.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/jhnstn/gutenberg-mobile/pull/31

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.